### PR TITLE
calculate summary for entire time range

### DIFF
--- a/configs/icds-7lakh-jan2019.yml
+++ b/configs/icds-7lakh-jan2019.yml
@@ -1,0 +1,639 @@
+estimation_buffer: 0.2
+estimation_growth_factor: 0.01  # buffer increases by 1% per month
+storage_buffer: 0.33  # keep max storage at 75% of disk
+storage_display_unit: TB
+
+summary_dates:
+#  - '2018-10'
+#  - '2018-12'
+#  - '2019-02'
+#  - '2019-04'
+#  - '2019-06'
+  - '2019-12'
+
+vm_os_storage_gb: 50
+vm_os_storage_group: 'VM_os'
+
+usage:
+  # TODO: adjust to match https://docs.google.com/spreadsheets/d/1PbLrv70Cp4gablzGyLdGEgxApw5376oNslZKlncT8iM/edit#gid=2043695881
+  users:
+    model: 'date_range_value'
+    ranges:
+      # User counts based on historical data
+#      - ['20170101', '20170201', 500]
+#      - ['20170301', 20000]
+#      - ['20170401', 40000]
+#      - ['20170501', '20171001', 50000]
+#      - ['20171101', 60000]
+#      - ['20171201', '20180301', 90000]
+#      - ['20180401', '20180501', 100000]
+#      - ['20180601', '20181201', 115000]
+#      - ['20190101', 120000]
+      - ['20180901', '20181201', 115000]
+      - ['20190101', '20190201', 140000]
+      - ['20190301', '20190401', 140000]
+      - ['20190501', '20191201', 700000]
+
+  # LS User as a percent of total User
+  ls_users:
+    model: 'derived_factor'
+    dependant_field: 'users'
+    factor: 0.05
+  # Number of formaplayer user from X date to Y
+  formplayer_users:
+    model: 'date_range_value'
+    ranges:
+      - ['20180901', '20191201', 1000]
+
+  #Number of forms per user per month
+  forms_monthly:
+    model: 'derived_factor'
+    dependant_field: 'users'
+    factor: 1000
+  forms_daily:
+    model: 'derived_factor'
+    dependant_field: 'forms_monthly'
+    factor: 0.03
+  # Total Forms ever created
+  forms_total:
+    model: 'cumulative'
+    dependant_field: 'forms_monthly'
+    start_with: 329680028   # from ES form index (total docs)
+
+  #Number of cases per user per month
+  cases_total:
+    model: 'baseline_with_growth'
+    dependant_field: 'users'
+    baseline: 1000  # inflated number by MWCD. Actual probably closer to 1000
+    monthly_growth: 100  # guess (4 cases for every new person case)
+    start_with: 204427935   # from ES case index (total docs)
+
+  # Number of cases updated per user per month
+  case_transactions:
+    model: 'derived_factor'
+    dependant_field: 'users'
+    factor: 1000  # inflated number by MWCD. Actual closer to 1000
+  # Total Case Transaction
+  case_transactions_total:
+    model: 'cumulative'
+    dependant_field: 'case_transactions'
+    start_with: 1240906740
+
+  # Case indexes ever created
+  case_indices:
+    model: 'derived_factor'
+    dependant_field: 'cases_total'
+    factor: 1  # case index count (from SQL) / case count
+
+  # used for SMS & UCR calculations
+  person_cases_total:
+    model: 'baseline_with_growth'
+    dependant_field: 'users'
+    baseline: 1000
+    monthly_growth: 28  # https://confluence.dimagi.com/display/ICDS/Case+Structure+and+Workflow#CaseStructureandWorkflow-CASCaseSizingEstimates
+
+  # assume 100% phone number capture rate
+  beneficiary_phone_numbers:
+    model: 'derived_factor'
+    dependant_field: 'person_cases_total'
+    factor: 1  # 100% seeding
+  phone_numbers:
+    model: 'derived_sum'
+    dependant_fields:
+      - 'beneficiary_phone_numbers'
+      - 'users'  # 100% seeding
+      - 'ls_users'  # 100% seeding
+
+  pregancy_cases:
+    model: 'baseline_with_growth'
+    dependant_field: 'users'
+    baseline: 6
+    monthly_growth: 1
+  child_cases:
+    model: 'baseline_with_growth'
+    dependant_field: 'users'
+    baseline: 100
+    monthly_growth: 1
+  ledgers_preg:
+    model: 'derived_factor'
+    dependant_field: 'pregancy_cases'
+    factor: 5
+  ledgers_child:
+    model: 'derived_factor'
+    dependant_field: 'child_cases'
+    factor: 35
+  ledgers_total:
+    model: 'derived_sum'
+    dependant_fields:
+      - 'ledgers_preg'
+      - 'ledgers_child'
+  ledger_transactions:
+    model: 'derived_factor'
+    dependant_field: 'ledgers_total'
+    factor: 2  # 2 transactions per ledger (ever)
+  ledger_updates_preg:
+    model: 'derived_factor'
+    dependant_field: 'pregancy_cases_baseline'  # active pregnancy cases
+    factor: 0.6
+  ledger_updates_child:
+    model: 'derived_factor'
+    dependant_field: 'child_cases_baseline'  # active child cases
+    factor: 0.6
+  ledger_updates_monthly:
+    model: 'derived_sum'
+    dependant_fields:
+      - 'ledger_updates_preg'
+      - 'ledger_updates_child'
+
+  synclogs:
+    model: 'derived_factor'
+    dependant_field: 'users'
+    factor: 60  # estimate from data analysis (SQL)
+  synclogs_total:
+    model: 'cumulative_limited_lifespan'
+    dependant_field: 'synclogs'
+    lifespan: 2  # we only keep synclogs for 2 months
+
+  images:
+    model: 'derived_factor'
+    dependant_field: 'users'
+    factor: 600  # daily feeding + THR + AG
+  images_total:
+    model: 'cumulative_limited_lifespan'
+    dependant_field: 'images'
+    lifespan: 3  # we only keep images for 3 months
+
+  # This is modelled because it accounts for significant storage in the main PG database
+  # This model could be improved or we find another way to account for this data
+  # Data taken from datadog in Jan 2019. Table size peaks at 1.2M rows (120K active users)
+  async_indicators:
+    model: 'derived_factor'
+    dependant_field: 'users'
+    factor: 50  # inflated to be safe
+
+  # See https://docs.google.com/spreadsheets/d/1vzp5kLHBm6IXKI39LTDS2pN69uMryXuBkpl7c8sxik8/edit#gid=1536669590 for sms estimates
+  # (old https://docs.google.com/spreadsheets/d/16evR_N95TUBFlIr3D3ojasX7yN4odDOxH5mgcF6VCkQ/edit#gid=0)
+### PHASE 1 SMS
+  sms_monthly_total:
+    model: 'derived_factor'
+    dependant_field: 'users'
+    factor: 10  # current usage of 10 messages per user per month (avg)
+  sms_total:
+    model: 'cumulative'
+    dependant_field: 'sms_monthly_total'
+    start_with: 3438200
+  sms_models_total:
+    model: 'derived_factor'
+    dependant_field: 'sms_total'
+    factor: 10  # sms (1) + smsbillables (1) + messagingevent (4) + messagingsubevent (4)
+### PHASE 2 SMS (assuming 100% phone number capture rate)
+#  sms_adolescent_girls:
+#    model: 'derived_factor'
+#    dependant_field: 'users'
+#    factor: 60  # 20 adolescent girls per aws x 3 messages per month
+#  sms_pregnancies:
+#    model: 'derived_factor'
+#    dependant_field: 'users'
+#    factor: 20  # 4 pregnancies per awc X 5 messages per month
+#  sms_lactating_women:
+#    model: 'derived_factor'
+#    dependant_field: 'users'
+#    factor: 35  # 7 lactating women per awc X 5 messages per month
+#  sms_aww:
+#    model: 'derived_factor'
+#    dependant_field: 'users'
+#    factor: 7  # 7 per month per user
+#  sms_ls:
+#    model: 'derived_factor'
+#    dependant_field: 'ls_users'
+#    factor: 5  # 5 per month per user
+#  sms_monthly_total:
+#    model: 'derived_sum'
+#    start_with: 3438200
+#    dependant_fields:
+#      - 'sms_adolescent_girls'
+#      - 'sms_pregnancies'
+#      - 'sms_lactating_women'
+#      - 'sms_aww'
+#      - 'sms_ls'
+#  sms_total:
+#    model: 'cumulative_limited_lifespan'
+#    dependant_field: 'sms_monthly_total'
+#    lifespan: 3
+#  sms_models_total:
+#    model: 'derived_factor'
+#    dependant_field: 'sms_total'
+#    factor: 10  # sms (1) + smsbillables (1) + messagingevent (4) + messagingsubevent (4)
+
+  # casetimedscheduleinstance table in shard database
+  sms_schedule_instances_total:
+    model: 'derived_factor'
+    dependant_field: 'person_cases_total'
+    factor: 1  # rough guess
+
+  kafka_changes:
+    model: 'derived_sum'
+    dependant_fields:
+      - 'forms_monthly'
+      - 'cases_total_monthly'
+      - 'case_transactions'
+      - 'ledger_updates_monthly'
+      - 'synclogs'
+      - 'sms_monthly_total'
+  kafka_changes_total:
+    model: 'cumulative_limited_lifespan'
+    dependant_field: 'kafka_changes'
+    lifespan: 2  # keep kafka changes for 2 months
+
+services:
+  pg_shards:
+    # this should have standbys for HA
+    # need higher performing SSDs
+    usage_capacity_per_node: 25000
+    include_ha_resources: True
+    storage:
+      group: 'SSD'
+      data_models:
+        - referenced_field: 'forms_total'
+          unit_size: 1200
+        - referenced_field: 'cases_total'
+          unit_size: 1800
+        - referenced_field: 'case_indices'
+          unit_size: 380
+        - referenced_field: 'case_transactions_total'
+          unit_size: 515
+        - referenced_field: 'ledgers_total'
+          unit_size: 450
+        - referenced_field: 'ledger_transactions'
+          unit_size: 420
+        - referenced_field: 'images_total'
+          unit_size: 370
+        - referenced_field: 'sms_schedule_instances_total'
+          unit_size: 683
+    process:
+      cores_per_node: 32
+      ram_per_node: 128
+
+  pg_proxy:
+    usage_capacity_per_node: 150000
+    storage_scales_with_nodes: True
+    storage:
+      group: 'VM_other'
+      static_baseline: 200GB
+      override_storage_buffer: 0
+      override_estimation_buffer: 0
+    process:
+      cores_per_node: 16
+      ram_per_node: 64
+
+  pg_main:
+    usage_capacity_per_node: 150000
+    storage_scales_with_nodes: True
+    min_nodes: 2
+    storage:
+      group: 'SSD'
+      static_baseline: 250GB  # to account for other static tables
+      data_models:
+        - referenced_field: 'phone_numbers'
+          unit_size: 550
+        - referenced_field: 'users'
+          unit_size: 1600
+        - referenced_field: 'async_indicators'
+          unit_size: 6626
+        - referenced_field: 'sms_models_total'
+          unit_size: 510  # averaged over all models taking model ratios into account
+    process:
+      cores_per_node: 32
+      ram_per_node: 128
+
+  # planning to shard this
+  pg_synclogs:
+    usage_capacity_per_node: 250000
+    storage:
+      group: 'SSD'
+      data_models:
+        - referenced_field: 'synclogs'
+          unit_size: 210000
+    process:
+      cores_per_node: 32
+      ram_per_node: 128
+
+  couchdb:
+    usage_capacity_per_node: 50000
+    min_nodes: 3
+    storage:
+      group: 'SSD'
+      redundancy_factor: 3
+      static_baseline: 50GB  # to account for other databases
+      override_storage_buffer: 0.8  # space for compaction
+      data_models:
+        - referenced_field: 'users'
+          unit_size: 600000   # disk size / doc count of icds @ 2017-12-13
+    process:
+      cores_per_node: 16
+      ram_per_node: 64
+
+  es_datanode:
+    usage_capacity_per_node: 15000
+    min_nodes: 3
+    storage:
+      group: 'SAS'
+      redundancy_factor: 2
+      data_models:
+        - referenced_field: 'forms_total'
+          unit_size: 5500
+        - referenced_field: 'cases_total'
+          unit_size: 1800
+        - referenced_field: 'case_transactions_total'
+          unit_size: 250
+        - referenced_field: 'ledgers_total'
+          unit_size: 500
+        - referenced_field: 'sms_total'
+          unit_size: 675
+    process:
+      cores_per_node: 16
+      ram_per_node: 64
+
+  es_master:
+    static_number: 6
+    storage_scales_with_nodes: True
+    storage:
+      group: 'VM_other'
+      static_baseline: 100GB
+      override_storage_buffer: 0
+      override_estimation_buffer: 0
+    process:
+      cores_per_node: 8
+      ram_per_node: 16
+
+  kafka:
+    usage_capacity_per_node: 200000
+    min_nodes: 3
+    storage:
+      group: 'SAS'
+      data_models:
+        - referenced_field: 'kafka_changes_total'
+          unit_size: 500
+    process:
+      cores_per_node: 16
+      ram_per_node: 32
+
+  riakcs:
+    usage_capacity_per_node: 50000
+    # avg attachment size of 12560 bytes (11000*0.96 + 50000*0.04)
+    # RAM requirement per key = 130b
+    # num keys = 10TB / (12560b x 3<redundancy factor>)
+    # RAM needed = 130b x num keys = 35GB (64GB avail per node)
+    max_storage_per_node: 25TB
+    min_nodes: 10
+    storage:
+      group: 'blob'
+      redundancy_factor: 3
+      static_baseline: 10TB  # to account for exports etc
+      data_models:
+        - referenced_field: 'forms_total'  # 96% of objects
+          unit_size: 11000
+        - referenced_field: 'images_total'  # 4% of objects
+          unit_size: 50000
+    process:
+      # current load quite low (~15%) (2018-10-11)
+      cores_per_node: 32
+      # need to be able to fit all keys in RAM since we're using bitcask backend
+      # Current usage is at 30% (2018-10-11)
+      ram_per_node: 128
+      ram_model:
+      - referenced_field: 'forms_total'
+        # key size (45 + 6 + 79) (overhead + bucket + key)
+        # bucket = 'blobdb'
+        # new keys are smaller but stick with old key length for safety:
+        #   new: form/xxxxxxxxxxxxxxuuidxxxxxxxxxxxxxx/Xpi-XM9CZvQ
+        #   old: form/xxxxxxxxxxxxxxuuidxxxxxxxxxxxxxx/form.xml.xxxxxxxxxxxxxxuuidxxxxxxxxxxxxxx
+        unit_size: 130
+      - referenced_field: 'images_total'
+        unit_size: 130
+      ram_redundancy_factor: 3
+      ram_static_baseline: 1  # per node
+
+  pg_ucr:
+    usage_capacity_per_node: 100000
+    storage_scales_with_nodes: True
+    min_nodes: 2
+    storage:
+      # This is a rough estimate.
+      # The person case UCR is 35% of total UCR usage.
+      group: 'SSD'
+      data_models:
+        - referenced_field: 'person_cases_total'
+          unit_size: 9000  # inflated to account for others UCRs
+        - referenced_field: 'cases_total'  # cumulative
+          unit_size: 4000  # to account for monthly data etc.
+    process:
+      cores_per_node: 32
+      ram_per_node: 256
+
+  pg_ucr_citus:
+    # This should have standby nodes
+    usage_capacity_per_node: 50000
+    include_ha_resources: True
+    storage:
+      # This is a rough estimate.
+      # The person case UCR is 35% of total UCR usage.
+      group: 'SSD'
+      # this was in the wrong place so got left out by mistake
+      data_models:
+        - referenced_field: 'person_cases_total'
+          unit_size: 9000  # inflated to account for others UCRs
+        - referenced_field: 'cases_total'  # cumulative
+          unit_size: 8000  # to account for monthly data etc.
+    process:
+      cores_per_node: 32
+      ram_per_node: 256
+
+  pg_warehouse:
+    usage_capacity_per_node: 300000
+    storage_scales_with_nodes: True
+    storage:
+      group: 'SSD'
+      data_models:
+        - referenced_field: 'forms_total'
+          unit_size: 4000  # to account for monthly data etc.
+    process:
+      cores_per_node: 16
+      ram_per_node: 128
+
+  pg_warehouse_citus:
+    # this should have replica nodes
+    usage_capacity_per_node: 150000
+    include_ha_resources: True
+    storage:
+      group: 'SSD'
+      # this got left out by mistakes
+      data_models:
+        - referenced_field: 'forms_total'
+          unit_size: 4000  # to account for monthly data etc.
+        - referenced_field: 'cases_total'  # add cases in case we add them later
+          unit_size: 4000
+    process:
+      cores_per_node: 32
+      ram_per_node: 256
+
+  pillowtop:  # will need to revamp this once combined pillows are rolled out
+    storage_scales_with_nodes: True
+    process:
+      cores_per_node: 16
+      ram_per_node: 48
+      cores_per_sub_process: 0.5
+      ram_per_sub_process: 0.7
+      sub_processes:
+        - name: 'other'
+          capacity: 7000  # covers all other pillows
+        - name: 'FormSubmissionMetadataTrackerPillow'
+          capacity: 7000
+        - name: 'XFormToElasticsearchPillow'
+          capacity: 7000
+        - name: 'kafka-ucr-static-forms'
+          capacity: 2500
+        - name: 'kafka-ucr-static-cases'
+          capacity: 1000
+        - name: 'CaseToElasticsearchPillow'
+          capacity: 1000
+    storage:
+      group: 'VM_other'
+      static_baseline: 100GB
+      override_storage_buffer: 0
+      override_estimation_buffer: 0
+
+  celery:
+    storage_scales_with_nodes: True
+    process:
+      cores_per_node: 16
+      ram_per_node: 48
+      cores_per_sub_process: 0.7  # reduced from 1 since we use django VMs as well
+      ram_per_sub_process: 0.5  # reduced from 0.7 since we use django VMs as well
+      sub_processes:
+        - name: 'reminder_case_update_queue'
+          capacity: 1000
+        - name: 'reminder_queue'
+          capacity: 30000
+        - name: 'ucr_indicator_queue'
+          capacity: 5000
+        - name: 'icds_dashboard_reports_queue'
+          capacity: 7000
+        - name: 'sms_queue'
+          capacity: 15000
+        - name: 'case_rule_queue'
+          capacity: 60000
+        - name: 'reminder_rule_queue'
+          capacity: 60000
+        - name: 'submission_reprocessing_queue'
+          capacity: 60000
+    storage:
+      group: 'VM_other'
+      static_baseline: 100GB
+      override_storage_buffer: 0
+      override_estimation_buffer: 0
+
+  django:
+    usage_capacity_per_node: 15000
+    storage_scales_with_nodes: True
+    process:
+      cores_per_node: 16
+      ram_per_node: 48
+    storage:
+      group: 'VM_other'
+      static_baseline: 100GB
+      override_storage_buffer: 0
+      override_estimation_buffer: 0
+
+  redis:
+    usage_capacity_per_node: 200000
+    min_nodes: 3
+    process:
+      cores_per_node: 12
+      ram_per_node: 96
+      ram_model:
+        - referenced_field: 'users'
+          unit_size: 50KB
+      ram_static_baseline: 33  # per node (assume only 50% ram is usable)
+    storage:
+      group: 'SAS'
+      data_models:
+        - referenced_field: 'users'
+          unit_size: 50KB
+
+  # potentially deploy redis as a cache for object storage if object storage
+  # performance isn't up to scratch
+  redis_os_cache:
+    usage_capacity_per_node: 150000
+    min_nodes: 3
+    process:
+      cores_per_node: 16  # can run multiple instances per VM if necessary
+      ram_per_node: 128
+      ram_model:
+        - referenced_field: 'forms_daily'
+          unit_size: 11KB
+      ram_static_baseline: 33  # per node (assume only 50% ram is usable)
+    storage:
+      group: 'SAS'
+      data_models:
+        - referenced_field: 'forms_daily'
+          unit_size: 11KB
+
+  nginx:  # limits for nginx not clear
+    usage_capacity_per_node: 250000
+    storage_scales_with_nodes: True
+    process:
+      cores_per_node: 16
+      ram_per_node: 64
+    storage:
+      group: 'VM_other'
+      static_baseline: 250GB  # logs etc
+      override_storage_buffer: 0
+      override_estimation_buffer: 0
+
+  rabbitmq:  # limits for rabbitmq not clear
+    static_number: 4
+    storage_scales_with_nodes: True
+    process:
+      cores_per_node: 32
+      ram_per_node: 128
+    storage:  # don't have a model for rabbitmq storage
+      group: 'SAS'
+      static_baseline: 500GB
+      override_storage_buffer: 0
+      override_estimation_buffer: 0
+
+  formplayer:
+    usage_capacity_per_node: 500
+    usage_field: 'formplayer_users'
+    process:
+      cores_per_node: 8
+      ram_per_node: 16
+    storage:
+      group: 'SAS'
+      data_models:
+        - referenced_field: 'formplayer_users'
+          unit_size: 200MB
+
+  airflow:
+    static_number: 4
+    storage_scales_with_nodes: True
+    process:
+      cores_per_node: 8
+      ram_per_node: 32
+    storage:
+      group: 'VM_other'
+      static_baseline: 100GB
+      override_storage_buffer: 0
+      override_estimation_buffer: 0
+
+  control:
+    static_number: 1
+    storage:
+      group: 'VM_other'
+      static_baseline: 100GB
+      override_storage_buffer: 0
+      override_estimation_buffer: 0
+    process:
+      cores_per_node: 4
+      ram_per_node: 8

--- a/core/output.py
+++ b/core/output.py
@@ -66,12 +66,15 @@ def write_summary_data(config, writer, summary_date, summary_data, user_count):
     )
 
 
-def write_raw_data(writer, usage, title, split=False):
-    if split:
-        sections = list(sorted({d[0] for d in usage}))
-        for section in sections:
-            writer.write_data_frame(usage[section], "{} ({})".format(title, section), 'Dates')
-    else:
+def write_raw_service_data(writer, service_data, summary_data, title):
+    sections = list(sorted({d[0] for d in service_data}))
+    for section in sections:
+        sdata = service_data[section]
+        sdata.columns = sdata.columns.get_level_values(1)
+        combined = sdata.join(summary_data[section])
+        writer.write_data_frame(combined, "{} ({})".format(title, section), 'Dates')
+
+def write_raw_data(writer, usage, title):
         writer.write_data_frame(usage, title, 'Dates')
 
 

--- a/core/summarize.py
+++ b/core/summarize.py
@@ -2,6 +2,7 @@ import math
 from collections import namedtuple, OrderedDict
 
 import pandas as pd
+import numpy as np
 
 from core.utils import format_date, to_storage_display_unit, tenth_round
 
@@ -36,85 +37,11 @@ def incremental_summaries(summary_comparisons, summary_dates):
     )
 
 
-def summarize_service_data(config, service_data, summary_date, date_number):
-    # formula for compound growth: start_val * (1 + growth factor)^N
-    estimation_buffer = config.estimation_buffer * (1 + config.estimation_growth_factor) ** date_number
-    snapshot = service_data.loc[summary_date]
+def summarize_service_data(config, summary_data, summary_date):
     storage_units = config.storage_display_unit
     to_display = to_storage_display_unit(storage_units)
-    to_gb = to_storage_display_unit('GB')
-    summary_df = pd.DataFrame()
-    for service_name, service_def in config.services.items():
-        service_snapshot = snapshot[service_name]
-        compute = service_snapshot['Compute']
-        data_storage = service_snapshot['Data Storage']['storage']
-        node_buffer = 0 if service_def.static_number else math.ceil(compute['VMs'] * float(estimation_buffer))
-        vms_suggested = math.ceil(compute['VMs'] + node_buffer)
-        vms_total = max(vms_suggested, service_def.min_nodes)
 
-        storage_estimation_buffer = estimation_buffer
-        if service_def.storage.override_estimation_buffer is not None:
-            storage_estimation_buffer = service_def.storage.override_estimation_buffer
-
-        if service_def.storage_scales_with_nodes:
-            data_storage_buffer = data_storage * float(storage_estimation_buffer)
-            data_storage_per_vm = data_storage + data_storage_buffer
-            data_storage_total = data_storage_per_vm * vms_total
-        elif vms_total > vms_suggested:
-            # in this case 'service_def.min_nodes' is more than what is being suggested
-            # so we want to add storage buffer and then distribute among all the nodes
-            data_storage_buffer = data_storage * float(storage_estimation_buffer)
-            data_storage_total = data_storage + data_storage_buffer
-            data_storage_per_vm = data_storage_total / vms_total
-        elif not compute['VMs']:
-            storage_buffer = data_storage * float(storage_estimation_buffer)
-            storage_estimation_buffer = data_storage * float(estimation_buffer)
-            data_storage_total = data_storage + storage_buffer + storage_estimation_buffer
-        else:
-            data_storage_per_vm = data_storage / compute['VMs']
-            data_storage_total = data_storage_per_vm * vms_total
-
-        include_ha_resources = service_def.include_ha_resources
-        data_storage_ha = data_storage_total if include_ha_resources else 0
-        data_storage_total = data_storage_total + data_storage_ha
-
-        cores = vms_total * service_def.process.cores_per_node if vms_total else 0
-        cores_ha = cores if include_ha_resources else 0
-        cores_total = cores + cores_ha
-
-        ram = vms_total * service_def.process.ram_per_node if vms_total else 0
-        ram_ha = ram if include_ha_resources else 0
-        ram_total = ram + ram_ha
-
-        vms_ha = vms_total if include_ha_resources else 0
-        vms_total = vms_total + vms_ha
-
-        os_storage = vms_total * config.vm_os_storage_gb * (1000.0 ** 3)
-        os_storage_ha = vms_ha * config.vm_os_storage_gb * (1000.0 ** 3)
-        data = OrderedDict([
-            ('Cores Per VM', service_def.process.cores_per_node),
-            ('Cores HA', cores_ha),
-            ('Cores Total', cores_total),
-            ('RAM Per VM', service_def.process.ram_per_node),
-            ('RAM HA (GB)', ram_ha),
-            ('RAM Total (GB)', ram_total),
-            ('Data Storage Per VM (GB)', tenth_round(to_gb((data_storage_per_vm) if compute['VMs'] else 0))),
-            ('Data Storage HA (%s)' % storage_units, tenth_round(to_display(math.ceil(data_storage_ha)))),
-            ('Data Storage Total (%s)' % storage_units, tenth_round(to_display(math.ceil(data_storage_total)))),
-            ('Data Storage RAW (includes HA) (%s)' % storage_units, to_display(data_storage + data_storage_ha)),
-            ('VMs HA', vms_ha),
-            ('VMs Total', vms_total),
-            ('VM Buffer', node_buffer),
-            ('Buffer %', estimation_buffer),
-            ('OS Storage HA (GB)', math.ceil(to_gb(os_storage_ha))),
-            ('OS Storage Total (Bytes)', os_storage),
-            ('OS Storage Total (GB)', math.ceil(to_gb(os_storage))),
-            ('Storage Group', service_def.storage.group),
-        ])
-        combined = pd.Series(name=service_name, data=data)
-        summary_df[service_name] = combined
-
-    summary_by_service = summary_df.T
+    summary_by_service = summary_data[:, summary_date].T
     summary_by_service.sort_index(inplace=True)
 
     by_type = summary_by_service.groupby('Storage Group')['Data Storage Total (%s)' % storage_units].sum()
@@ -136,6 +63,114 @@ def summarize_service_data(config, service_data, summary_date, date_number):
     return ServiceSummary(summary_by_service, storage_by_group)
 
 
+def get_summary_data(config, service_data):
+    """Compute summary data for each month and each service"""
+
+    # formula for compound growth: start_val * (1 + growth factor)^N
+    ebi = pd.Series(range(0, len(service_data.index)), index=service_data.index)
+    estimation_buffer = config.estimation_buffer * (1 + config.estimation_growth_factor) ** ebi
+    estimation_buffer = estimation_buffer.map(float)
+
+    storage_units = config.storage_display_unit
+    to_display = to_storage_display_unit(storage_units)
+    to_gb = to_storage_display_unit('GB')
+    summary_df = dict()
+    for service_name, service_def in config.services.items():
+        service_snapshot = service_data[service_name]
+        compute = service_snapshot['Compute']
+        data_storage = service_snapshot['Data Storage']['storage']
+        node_buffer = 0 if service_def.static_number else (compute['VMs'] * estimation_buffer).map(np.ceil)
+        vms_suggested = (compute['VMs'] + node_buffer).map(np.ceil)
+        vms_total = pd.DataFrame([
+            vms_suggested,
+            pd.Series([service_def.min_nodes] * len(vms_suggested), index=vms_suggested.index)
+        ]).max()
+
+        storage_estimation_buffer = estimation_buffer
+        if service_def.storage.override_estimation_buffer is not None:
+            storage_estimation_buffer = pd.Series(
+                [float(service_def.storage.override_estimation_buffer)] * len(service_data.index),
+                index=service_data.index
+            )
+        # this is True if 'service_def.min_nodes' is more than what is being suggested
+        vm_total_gt = vms_total > vms_suggested
+        data_storage_buffer = data_storage * storage_estimation_buffer
+
+        if service_def.storage_scales_with_nodes:
+            # in this case total storage = storage * VM number
+            data_storage_per_vm = data_storage + data_storage_buffer
+            data_storage_total = data_storage_per_vm * vms_total
+        elif True in set(vm_total_gt):
+            # in this case 'service_def.min_nodes' is more than what is being suggested
+            # so we want to add storage buffer and then distribute among all the nodes
+            # but only where vm_total_gt = False
+
+            # 1. calculate storage per VM and total for case where ``vms_total <= vms_suggested``
+            vm_total_lte = np.invert(vm_total_gt)
+            data_storage_per_vm_lt = data_storage / compute['VMs'] * vm_total_lte
+            data_storage_total_lt = data_storage_per_vm_lt * vms_total * vm_total_lte
+
+            # 2. calculate storage per VM and total for case where ``vms_total > vms_suggested``
+            data_storage_total_gt = (data_storage + data_storage_buffer) * vm_total_gt
+            data_storage_per_vm_gt = data_storage_total_gt / vms_total * vm_total_gt
+
+            # combine 1 & 2 and select values according to vm_total_gt
+            data_storage_total = data_storage_total_lt + data_storage_total_gt
+            data_storage_per_vm = data_storage_per_vm_lt + data_storage_per_vm_gt
+        elif not compute['VMs'].any():
+            # if this service doesn't have any compute resources
+            storage_buffer = data_storage * float(storage_estimation_buffer)
+            storage_estimation_buffer = data_storage * float(estimation_buffer)
+            data_storage_total = data_storage + storage_buffer + storage_estimation_buffer
+        else:
+            # data is spread across all VMs
+            data_storage_per_vm = data_storage / compute['VMs']
+            data_storage_total = data_storage_per_vm * vms_total
+
+        zero = pd.Series([0] * len(vms_suggested), index=vms_suggested.index)
+        include_ha_resources = service_def.include_ha_resources
+        data_storage_ha = data_storage_total if include_ha_resources else zero.copy()
+        data_storage_total = data_storage_total + data_storage_ha
+
+        cores = vms_total * service_def.process.cores_per_node if vms_total.any() else zero.copy()
+        cores_ha = cores if include_ha_resources else zero.copy()
+        cores_total = cores + cores_ha
+
+        ram = vms_total * service_def.process.ram_per_node if vms_total.any() else zero.copy()
+        ram_ha = ram if include_ha_resources else zero.copy()
+        ram_total = ram + ram_ha
+
+        vms_ha = vms_total if include_ha_resources else zero.copy()
+        vms_total = vms_total + vms_ha
+
+        os_storage = vms_total * config.vm_os_storage_gb * (1000.0 ** 3)
+        os_storage_ha = vms_ha * config.vm_os_storage_gb * (1000.0 ** 3)
+        data = OrderedDict([
+            ('Cores Per VM', service_def.process.cores_per_node),
+            ('Cores HA', cores_ha),
+            ('Cores Total', cores_total),
+            ('RAM Per VM', service_def.process.ram_per_node),
+            ('RAM HA (GB)', ram_ha),
+            ('RAM Total (GB)', ram_total),
+            ('Data Storage Per VM (GB)', tenth_round(to_gb((data_storage_per_vm) if compute['VMs'].any() else zero.copy()))),
+            ('Data Storage HA (%s)' % storage_units, tenth_round(to_display((data_storage_ha).map(np.ceil)))),
+            ('Data Storage Total (%s)' % storage_units, tenth_round(to_display((data_storage_total).map(np.ceil)))),
+            ('Data Storage RAW (includes HA) (%s)' % storage_units, to_display(data_storage + data_storage_ha)),
+            ('VMs HA', vms_ha),
+            ('VMs Total', vms_total),
+            ('VM Buffer', node_buffer),
+            ('Buffer %', estimation_buffer),
+            ('OS Storage HA (GB)', (to_gb(os_storage_ha)).map(np.ceil)),
+            ('OS Storage Total (Bytes)', os_storage),
+            ('OS Storage Total (GB)', (to_gb(os_storage)).map(np.ceil)),
+            ('Storage Group', service_def.storage.group),
+        ])
+        combined = pd.DataFrame(data=data)
+        summary_df[service_name] = combined
+
+    return pd.Panel(summary_df)  # toto: use multiindex dataframe
+
+
 def compare_summaries(config, summaries_by_date):
     data_storage_series = []
     storage_by_group_series = []
@@ -145,7 +180,7 @@ def compare_summaries(config, summaries_by_date):
     for date in dates:
         summary_data = summaries_by_date[date]
         data_storage_series.append(summary_data.service_summary['Data Storage Total (%s)' % storage_units])
-        storage_by_group_series.append(summary_data.storage_by_group['Rounded Total (%s)' % storage_units])
+        storage_by_group_series.append(summary_data.storage_by_group)
         compute = summary_data.service_summary[['Cores Total', 'RAM Total (GB)', 'VMs Total']]
         compute = compute.rename({'Cores Total': 'Cores', 'RAM Total (GB)': 'RAM (GB)', 'VMs Total': 'VMs'}, axis=1)
         compute_series.append(compute)

--- a/core/summarize.py
+++ b/core/summarize.py
@@ -119,8 +119,8 @@ def get_summary_data(config, service_data):
             data_storage_per_vm = data_storage_per_vm_lt + data_storage_per_vm_gt
         elif not compute['VMs'].any():
             # if this service doesn't have any compute resources
-            storage_buffer = data_storage * float(storage_estimation_buffer)
-            storage_estimation_buffer = data_storage * float(estimation_buffer)
+            storage_buffer = data_storage * storage_estimation_buffer
+            storage_estimation_buffer = data_storage * estimation_buffer
             data_storage_total = data_storage + storage_buffer + storage_estimation_buffer
         else:
             # data is spread across all VMs

--- a/core/summarize.py
+++ b/core/summarize.py
@@ -140,7 +140,7 @@ def get_summary_data(config, service_data):
         ram_ha = ram if include_ha_resources else zero.copy()
         ram_total = ram + ram_ha
 
-        vms_ha = vms_total if include_ha_resources else zero.copy()
+        vms_ha = vms_total.copy() if include_ha_resources else zero.copy()
         vms_total = vms_total + vms_ha
 
         os_storage = vms_total * config.vm_os_storage_gb * (1000.0 ** 3)

--- a/core/utils.py
+++ b/core/utils.py
@@ -1,5 +1,6 @@
-import math
 import re
+
+import numpy as np
 
 byte_map = {
     'KB': 1000.0,
@@ -41,13 +42,12 @@ def storage_display_to_bytes(display_value):
     return from_storage_display_unit(units)(value)
 
 
-def tenth_round(value):
+def tenth_round(series):
     """Remove some precision by rounding to the power of 10 nearest
     to 1% of the value
     """
-    if not value:
-        return value
-    tenth = value * 0.01
-    pow = round(math.log10(tenth))
+    tenth = series * 0.01
+    pow = tenth.map(np.log10).map(np.round)
+    # pow = round(math.log10(tenth))
     round_val = 10 ** pow
-    return math.ceil(value / round_val) * round_val
+    return (series / round_val).map(np.ceil) * round_val

--- a/run_model.py
+++ b/run_model.py
@@ -60,8 +60,8 @@ if __name__ == '__main__':
 
         if len(summary_dates) == 1:
             date = summary_dates[0]
-            summary_data = summaries[date]
-            write_summary_data(config, writer, date, summary_data, user_count[date])
+            summary_data_snapshot = summaries[date]
+            write_summary_data(config, writer, date, summary_data_snapshot, user_count[date])
         else:
             summary_comparisons = compare_summaries(config, summaries)
             incrementals = incremental_summaries(summary_comparisons, summary_dates)

--- a/run_model.py
+++ b/run_model.py
@@ -8,7 +8,7 @@ from core.config import config_from_path
 from core.generate import generate_usage_data, generate_service_data
 from core.output import write_raw_data, write_summary_comparisons, write_summary_data
 from core.summarize import incremental_summaries, \
-    summarize_service_data, compare_summaries
+    summarize_service_data, compare_summaries, get_summary_data
 from core.writers import ConsoleWriter
 from core.writers import ExcelWriter
 
@@ -53,9 +53,9 @@ if __name__ == '__main__':
         summaries = {}
         user_count = {}
         date_list = list(usage.index.to_series())
+        summary_data = get_summary_data(config, service_data)
         for date in summary_dates:
-            date_number = date_list.index(date)
-            summaries[date] = summarize_service_data(config, service_data, date, date_number)
+            summaries[date] = summarize_service_data(config, summary_data, date)
             user_count[date] = usage.loc[date]['users']
 
         if len(summary_dates) == 1:
@@ -65,8 +65,8 @@ if __name__ == '__main__':
         else:
             summary_comparisons = compare_summaries(config, summaries)
             incrementals = incremental_summaries(summary_comparisons, summary_dates)
-            write_summary_comparisons(config, writer, user_count, incrementals, prefix='Incremental ')
             write_summary_comparisons(config, writer, user_count, summary_comparisons)
+            write_summary_comparisons(config, writer, user_count, incrementals, prefix='Incremental ')
 
             for date in sorted(summaries):
                 write_summary_data(config, writer, date, summaries[date], user_count[date])

--- a/run_model.py
+++ b/run_model.py
@@ -6,7 +6,7 @@ import pandas as pd
 
 from core.config import config_from_path
 from core.generate import generate_usage_data, generate_service_data
-from core.output import write_raw_data, write_summary_comparisons, write_summary_data
+from core.output import write_raw_data, write_summary_comparisons, write_summary_data, write_raw_service_data
 from core.summarize import incremental_summaries, \
     summarize_service_data, compare_summaries, get_summary_data
 from core.writers import ConsoleWriter
@@ -74,7 +74,7 @@ if __name__ == '__main__':
         if is_excel:
             # only write raw data if writing to Excel
             write_raw_data(writer, usage, 'Usage')
-            write_raw_data(writer, service_data, 'Raw Data', split=True)
+            write_raw_service_data(writer, service_data, summary_data, 'Raw Data')
 
             with open(args.config, 'r') as f:
                 config_string = 'Git commit: {}\n\n{}'.format(


### PR DESCRIPTION
Instead of calculating the 'summary' data only at the 'summary dates' we calculate it for all the months and write it to the raw data tabs for the services to make it easier to inspect the data.

This change just converts calculations to operate on a DataFrame / Series instead of a single data point. The date summaries then just select the data for the specific month.